### PR TITLE
Make use of block cache

### DIFF
--- a/configs/opinicus_config
+++ b/configs/opinicus_config
@@ -386,6 +386,7 @@ CONFIG_CMD_PING=y
 #
 # Misc commands
 #
+CONFIG_CMD_BLOCK_CACHE=y
 CONFIG_CMD_BMP=y
 # CONFIG_CMD_CACHE is not set
 # CONFIG_CMD_TIME is not set
@@ -452,7 +453,7 @@ CONFIG_OF_TRANSLATE=y
 # CONFIG_ADC_SANDBOX is not set
 # CONFIG_BLK is not set
 CONFIG_DISK=y
-# CONFIG_BLOCK_CACHE is not set
+CONFIG_BLOCK_CACHE=y
 
 #
 # Clock


### PR DESCRIPTION
By using block cache, we can safely use partitions that has features
such as extents. Without block cache, reading from partitions having
these features is extremely slow. Block cache is usually disabled for
very memory constrained systems.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>